### PR TITLE
Empty project is updated with respect to example/empty

### DIFF
--- a/data/dataset/dataset.yaml
+++ b/data/dataset/dataset.yaml
@@ -7,7 +7,6 @@ apiVersion: 1
 name: "dataset"
 type: source
 
-materializations:
-  - type: table
-    target: layer
+materialization:
+    target: layer-public-datasets
     table_name: "dataset"

--- a/data/features/dataset.yml
+++ b/data/features/dataset.yml
@@ -13,9 +13,5 @@ description: "My Features"
 
 features: []
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: []
-
-materializations: []
+materialization:
+    target: layer-public-datasets


### PR DESCRIPTION
It was out of date before and we were asking our end-users to clone this out-of-date empty repo on our website.